### PR TITLE
Feat: bump Applicaster android sdk core to 6.3.0 and add version to project properties

### DIFF
--- a/android_quickbrick_app/build.gradle
+++ b/android_quickbrick_app/build.gradle
@@ -68,11 +68,16 @@ def getVersionName = { ->
     }
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 dependencies {
     // Check if an open SDK is defined - if not use the closed one.
     if (!findProject(':applicaster-android-sdk') || project.hasProperty('forceClosedDependencies')) {
         // core is the same project as applicaster-android-sdk but uses a different flavor
-        api ("com.applicaster:applicaster-android-sdk-core:6.2.0") {
+        def sdkVersion = safeExtGet('applicaster_android_sdk_core_version', '6.3.0')
+        api ("com.applicaster:applicaster-android-sdk-core:${sdkVersion}") {
             exclude group: 'com.applicaster', module: 'react-native'
         }
         api "com.facebook.react:react-native:+"

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,5 @@ android.enableR8=false
 
 # roboelectric
 android.enableUnitTestBinaryResources = true
+
+applicaster_android_sdk_core_version=6.3.0


### PR DESCRIPTION
Bump Applicaster Android SDK core version to 6.3.0 to get access to the new logging options.
Also, now we have version as a project property so source-form plugins can use it.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [x] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
