### PR TITLE
Fix: add rules to keep all plugin interfaces

### DIFF
--- a/rake/templates/app_proguard-rules.pro
+++ b/rake/templates/app_proguard-rules.pro
@@ -19,6 +19,14 @@
 -keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactProp <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactPropGroup <methods>; }
 
+# keep all the plugins
+
+-keep public class * implements com.applicaster.plugin_manager.PluginI
+-keep public class * implements com.applicaster.plugin_manager.GenericPluginI
+-keep public class * implements com.applicaster.plugin_manager.crashlog.CrashlogPlugin
+-keep public class * implements com.applicaster.plugin_manager.push_plugin.PushContract
+-keep public class * implements com.applicaster.plugin_manager.dependencyplugin.base.interfaces.**
+
 ## react-native-fast-image
 
 -keep public class com.dylanvann.fastimage.* {*;}


### PR DESCRIPTION
Right now, some of the plugins can be removed by proguard since they miss proper rules in the manifests.
But since we know interfaces these plugin implement, we can add it once on a top level.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
