### PR TITLE
Fix: webview react native module was not imported

### DIFF
--- a/android_quickbrick_app/build.gradle
+++ b/android_quickbrick_app/build.gradle
@@ -113,6 +113,8 @@ dependencies {
     
     implementation project(':react-native-fast-image')
 
+    implementation project(':react-native-webview')
+
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'
     }

--- a/rake/templates/qb_settings.gradle.erb
+++ b/rake/templates/qb_settings.gradle.erb
@@ -1,7 +1,8 @@
-include ':app', ':android_quickbrick_app', ':react-native-netinfo', ':react-native-community_viewpager', ':react-native-linear-gradient', 'react-native-svg', ':react-native-fast-image' <%= project_dependencies_names %>
+include ':app', ':android_quickbrick_app', ':react-native-netinfo', ':react-native-community_viewpager', ':react-native-linear-gradient', 'react-native-svg', ':react-native-fast-image', ':react-native-webview' <%= project_dependencies_names %>
 project(':react-native-netinfo').projectDir = new File('node_modules/@react-native-community/netinfo/android')
 project(':react-native-community_viewpager').projectDir = new File('node_modules/@react-native-community/viewpager/android')
 project(':react-native-linear-gradient').projectDir = new File('node_modules/react-native-linear-gradient/android')
 project(':react-native-svg').projectDir = new File('node_modules/react-native-svg/android')
 project(':react-native-fast-image').projectDir = new File('node_modules/@applicaster/react-native-fast-image/android')
+project(':react-native-webview').projectDir = new File('node_modules/react-native-webview/android')
 <%= project_dependencies_paths %>

--- a/spec/fixtures/files/qb_external_projects_settings.gradle
+++ b/spec/fixtures/files/qb_external_projects_settings.gradle
@@ -1,8 +1,9 @@
-include ':app', ':android_quickbrick_app', ':react-native-netinfo', ':react-native-community_viewpager', ':react-native-linear-gradient', 'react-native-svg', ':react-native-fast-image' ,':project-name',':project-for-@applicaster-name'
+include ':app', ':android_quickbrick_app', ':react-native-netinfo', ':react-native-community_viewpager', ':react-native-linear-gradient', 'react-native-svg', ':react-native-fast-image', ':react-native-webview' ,':project-name',':project-for-@applicaster-name'
 project(':react-native-netinfo').projectDir = new File('node_modules/@react-native-community/netinfo/android')
 project(':react-native-community_viewpager').projectDir = new File('node_modules/@react-native-community/viewpager/android')
 project(':react-native-linear-gradient').projectDir = new File('node_modules/react-native-linear-gradient/android')
 project(':react-native-svg').projectDir = new File('node_modules/react-native-svg/android')
 project(':react-native-fast-image').projectDir = new File('node_modules/@applicaster/react-native-fast-image/android')
+project(':react-native-webview').projectDir = new File('node_modules/react-native-webview/android')
 project(':project-name').projectDir = new File('project-path')
 project(':project-for-@applicaster-name').projectDir = new File('project-path')


### PR DESCRIPTION
Webview react native module was not imported in gradle files and templates.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
