### PR TITLE
Fix: use custom animated drawable AnimatedImageView for loading spinner

### DIFF
--- a/android_quickbrick_app/build.gradle
+++ b/android_quickbrick_app/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     // Check if an open SDK is defined - if not use the closed one.
     if (!findProject(':applicaster-android-sdk') || project.hasProperty('forceClosedDependencies')) {
         // core is the same project as applicaster-android-sdk but uses a different flavor
-        def sdkVersion = safeExtGet('applicaster_android_sdk_core_version', '6.4.0')
+        def sdkVersion = safeExtGet('applicaster_android_sdk_core_version', '6.4.1')
         api ("com.applicaster:applicaster-android-sdk-core:${sdkVersion}") {
             exclude group: 'com.applicaster', module: 'react-native'
         }

--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/views/AnimatedImageView.kt
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/views/AnimatedImageView.kt
@@ -1,0 +1,27 @@
+package com.applicaster.ui.views
+
+import android.content.Context
+import android.graphics.drawable.AnimationDrawable
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatImageView
+
+class AnimatedImageView : AppCompatImageView {
+
+    constructor(context: Context?)
+            : super(context) {
+        startDrawableAnimation()
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?)
+            : super(context, attrs) {
+        startDrawableAnimation()
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int)
+            : super(context, attrs, defStyleAttr) {
+        startDrawableAnimation()
+    }
+
+    private fun startDrawableAnimation() =
+            (drawable as? AnimationDrawable)?.start()
+}

--- a/android_quickbrick_app/src/main/res/layout-television/intro_splash_layout.xml
+++ b/android_quickbrick_app/src/main/res/layout-television/intro_splash_layout.xml
@@ -16,8 +16,8 @@
     <com.applicaster.ui.views.AnimatedImageView
         android:id="@+id/progress_bar"
         android:src="@drawable/image_loading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
         android:layout_gravity="bottom|center_horizontal"
         android:layout_marginBottom="50dp" />
 

--- a/android_quickbrick_app/src/main/res/layout-television/intro_splash_layout.xml
+++ b/android_quickbrick_app/src/main/res/layout-television/intro_splash_layout.xml
@@ -13,11 +13,11 @@
         android:contentDescription="@string/app_name"
         android:src="@drawable/splash_logo" />
 
-    <ProgressBar
+    <com.applicaster.ui.views.AnimatedImageView
         android:id="@+id/progress_bar"
-        android:indeterminateDrawable="@drawable/image_loading"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:src="@drawable/image_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom|center_horizontal"
         android:layout_marginBottom="50dp" />
 

--- a/android_quickbrick_app/src/main/res/layout/app_preloader.xml
+++ b/android_quickbrick_app/src/main/res/layout/app_preloader.xml
@@ -27,11 +27,11 @@
         android:layout_gravity="center"
         android:visibility="gone" />
 
-    <ImageView
+    <com.applicaster.ui.views.AnimatedImageView
         android:id="@+id/preloading_indicator"
-        android:indeterminateDrawable="@drawable/image_loading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:src="@drawable/image_loading"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
         android:layout_centerInParent="true"
         android:visibility="gone" />
 

--- a/android_quickbrick_app/src/main/res/layout/app_preloader.xml
+++ b/android_quickbrick_app/src/main/res/layout/app_preloader.xml
@@ -27,7 +27,7 @@
         android:layout_gravity="center"
         android:visibility="gone" />
 
-    <ProgressBar
+    <ImageView
         android:id="@+id/preloading_indicator"
         android:indeterminateDrawable="@drawable/image_loading"
         android:layout_width="wrap_content"

--- a/android_quickbrick_app/src/main/res/layout/intro_splash_layout.xml
+++ b/android_quickbrick_app/src/main/res/layout/intro_splash_layout.xml
@@ -16,8 +16,8 @@
     <com.applicaster.ui.views.AnimatedImageView
         android:id="@+id/progress_bar"
         android:src="@drawable/image_loading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
         android:layout_gravity="bottom|center"
         android:layout_marginBottom="50dp" />
 

--- a/android_quickbrick_app/src/main/res/layout/intro_splash_layout.xml
+++ b/android_quickbrick_app/src/main/res/layout/intro_splash_layout.xml
@@ -13,11 +13,11 @@
         android:contentDescription="@string/app_name"
         android:src="@drawable/splash_logo" />
 
-    <ProgressBar
+    <com.applicaster.ui.views.AnimatedImageView
         android:id="@+id/progress_bar"
-        android:indeterminateDrawable="@drawable/image_loading"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:src="@drawable/image_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom|center"
         android:layout_marginBottom="50dp" />
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,4 @@ android.enableR8=false
 # roboelectric
 android.enableUnitTestBinaryResources = true
 
-applicaster_android_sdk_core_version=6.4.0
+applicaster_android_sdk_core_version=6.4.1


### PR DESCRIPTION
Using ProgressBar causes artifacts on FireTV: image is drawn with sampling that wraps through image edges, has issues with scaling image (wrong dimensions are taken).

Fixed for https://applicaster.atlassian.net/browse/ZPP-2926

Before:
![image](https://user-images.githubusercontent.com/24409942/93513832-6b0dda00-f8f4-11ea-88f9-1c9b7101fbff.png)

After:
![image](https://user-images.githubusercontent.com/24409942/93518491-dbb7f500-f8fa-11ea-8549-0897e77e9944.png)


### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [ ] My PR is not introducing a UI change
- [x] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
