### PR TITLE
fix: enable R8 to fix release builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,8 +25,6 @@ android.useDeprecatedNdk=true
 android.useAndroidX=true
 android.enableJetifier=true
 
-android.enableR8=false
-
 # roboelectric
 android.enableUnitTestBinaryResources = true
 


### PR DESCRIPTION
Enabling R, since some release builds will fail without it.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [x] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
