### PR TITLE
feat: extracted buildToolsVersion, compileSdkVersion, minSdkVersion, targetSdkVersion as constants

### DIFF
--- a/android_quickbrick_app/build.gradle
+++ b/android_quickbrick_app/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.3'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions.encoding = 'ISO-8859-1'
 
@@ -15,8 +15,8 @@ android {
 
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION
-        targetSdkVersion TARGET_SDK_VERSION
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         consumerProguardFiles 'proguard-project.txt'

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,8 @@ glideVersion=4.11.0
 
 # must match version declared in applicaster-android-sdk-core
 firebaseBoMVersion=26.0.0
+
+buildToolsVersion=29.0.3
+# compileSdkVersion is declared in root gradle file due to typing issues
+minSdkVersion=19
+targetSdkVersion=29

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,5 +41,5 @@ firebaseBoMVersion=26.0.0
 
 buildToolsVersion=29.0.3
 # compileSdkVersion is declared in root gradle file due to typing issues
-minSdkVersion=19
+# minSdkVersion is declared in root gradle file due to zapp override option.
 targetSdkVersion=29

--- a/rake/lib/template_helper.rb
+++ b/rake/lib/template_helper.rb
@@ -12,6 +12,7 @@ class TemplateHelper
   include AndroidManifestHelper
 
   SDK_DEFAULT_QB_VERSION = "4.1.4"
+  SDK_DEFAULT_MIN_SDK_VERSION = 19
 
   def render_template(template_path, dst_path)
     helper_binding = binding
@@ -25,7 +26,7 @@ class TemplateHelper
   private
 
   def min_sdk_version
-    [19, ENV["min_sdk_version"].to_i].max
+    [SDK_DEFAULT_MIN_SDK_VERSION, ENV["min_sdk_version"].to_i].max
   end
 
   def app_name

--- a/rake/templates/qb_build.gradle.erb
+++ b/rake/templates/qb_build.gradle.erb
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "<%= bundle_identifier %>"
-        minSdkVersion <%= min_sdk_version %>
-        targetSdkVersion 29
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode <%= build_version %>
         versionName "<%= version_name %>"
         manifestPlaceholders = [

--- a/rake/templates/qb_top_level_build.gradle.erb
+++ b/rake/templates/qb_top_level_build.gradle.erb
@@ -95,5 +95,6 @@ subprojects {
     }
 }
 
-// this once can not be defined in the gradle properties due to typing issues
+ext.minSdkVersion=<%= min_sdk_version %>
+// this one can not be defined in the gradle properties due to typing issues
 ext.compileSdkVersion=29

--- a/rake/templates/qb_top_level_build.gradle.erb
+++ b/rake/templates/qb_top_level_build.gradle.erb
@@ -94,3 +94,6 @@ subprojects {
         }
     }
 }
+
+// this once can not be defined in the gradle properties due to typing issues
+ext.compileSdkVersion=29


### PR DESCRIPTION
Extracted buildToolsVersion, compileSdkVersion, minSdkVersion, targetSdkVersion as constants.
React native modules usually use these to define build configuration.
Having these inconsistent can cause build errors, especially on release. 

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [x] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
