### PR TITLE
feat: install all npm plugins if they used as project dependencies

### DIFF
--- a/rake/tasks/add_plugins_configurations.rake
+++ b/rake/tasks/add_plugins_configurations.rake
@@ -66,8 +66,6 @@ task generate_plugins: :dotenv do
     PluginsHelper.add_plugin_class_name(plugin)
     PluginsHelper.add_proguard_rules(plugin)
 
-    next unless plugin["react_native"]
-
     # React Native dependencies
     puts "Adding React Native #{plugin['name']} plugin...".yellow
 


### PR DESCRIPTION
feat: install all npm plugins if they used as project dependencies. No need for react_native: true flag anymore.


### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [x] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
