### PR TITLE
fix: OrientationEventListener is not disposed on activity death and crash the app on recreate

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
@@ -8,6 +8,9 @@ import android.text.TextUtils
 import android.view.KeyEvent
 import android.view.OrientationEventListener
 import androidx.annotation.RawRes
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.applicaster.plugin_manager.PluginManager
 import com.applicaster.ui.R
 import com.applicaster.ui.interfaces.HostActivityBase
@@ -100,7 +103,7 @@ class MainActivity : HostActivityBase() {
     }
 
     private fun initOrientationListener() {
-        object : OrientationEventListener(this) {
+        object : OrientationEventListener(this), LifecycleObserver {
             private var lastKnownRotation = 0
 
             /**
@@ -123,10 +126,16 @@ class MainActivity : HostActivityBase() {
                 }
             }
 
+            @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+            fun onActivityDestroy() {
+                disable()
+            }
+
             init {
                 if (canDetectOrientation()) {
                     enable()
                 }
+                lifecycle.addObserver(this)
             }
         }
     }


### PR DESCRIPTION
Crash happens when we have any background services, swipe the task from task manager, and relaunch the app.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
