### PR TITLE
feat: upgrade to com.android.tools.build:gradle:3.6.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ references:
     working_directory: *workspace_root
     resource_class: large
     docker:
-      - image: applicaster/zapp-platform-android-circleci-primary:1.0.0
+      - image: applicaster/zapp-platform-android-circleci-primary:1.1.0
         environment:
           ANDROID_HOME: /home/circleci/android-sdk
           JAVA_HOME: /usr/lib/jvm/java-1.8.0-openjdk-amd64

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -63,6 +63,8 @@ RUN sdkmanager \
     "extras;google;m2repository" \
     "extras;google;google_play_services"
 
+RUN sdkmanager --install "ndk;20.0.5594570"
+
 RUN rm -rf /usr/local/bin/node
 
 RUN mkdir -p /usr/local/nvm

--- a/rake/templates/qb_build.gradle.erb
+++ b/rake/templates/qb_build.gradle.erb
@@ -48,7 +48,7 @@ android {
         pickFirst 'META-INF/LICENSE'
         pickFirst 'META-INF/ASL2.0'
         pickFirst 'META-INF/NOTICE'
-        pickFirst 'META-INF/MANIFEST.MF'
+        exclude 'META-INF/MANIFEST.MF'
 
 
         // https://github.com/ReactiveX/RxJava/issues/4445

--- a/rake/templates/qb_top_level_build.gradle.erb
+++ b/rake/templates/qb_top_level_build.gradle.erb
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         <%= gms_google_services_classpath %>
         <%= strict_version_matcher_plugin_classpath %>
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/rake/templates/qb_top_level_build.gradle.erb
+++ b/rake/templates/qb_top_level_build.gradle.erb
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         <%= gms_google_services_classpath %>
         <%= strict_version_matcher_plugin_classpath %>
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/rake/templates/qb_top_level_build.gradle.erb
+++ b/rake/templates/qb_top_level_build.gradle.erb
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         <%= gms_google_services_classpath %>
         <%= strict_version_matcher_plugin_classpath %>
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
Minimal Android gradle plugin version for R8 minified builds to work on FireTV IAPs is 3.6.0, or disabling R8. But disabling R8 causes random crashes in other places, so trying to update gradle a bit.
https://developer.amazon.com/docs/in-app-purchasing/iap-obfuscate-the-code.html
```
 R8 is now compatible with IAP, so you no longer need to disable R8. IAP is compatible with Android Gradle plugin version 3.6.0 or higher. Follow the steps below to use IAP with R8.
```

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [x] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
