### PR TITLE
feat: disable MS AppCenter for debug builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,13 +134,18 @@ jobs:
       - run:
           name: Check app name with App Center
           command: |
-            if [ "$bundle_identifier" ]
+            if [ "$with_release" = "true" ];
             then
-              bundle exec rake app_center:prepare_app_data[${bundle_identifier}]
-              cat ${HOME}/${CIRCLE_PROJECT_REPONAME}/app_data.env
-              cat ${HOME}/${CIRCLE_PROJECT_REPONAME}/app_data.env >> $BASH_ENV
+              if [ "$bundle_identifier" ]
+              then
+                bundle exec rake app_center:prepare_app_data[${bundle_identifier}]
+                cat ${HOME}/${CIRCLE_PROJECT_REPONAME}/app_data.env
+                cat ${HOME}/${CIRCLE_PROJECT_REPONAME}/app_data.env >> $BASH_ENV
+              else
+                echo "Skipping the step, no bundle_identifier available."
+              fi
             else
-              echo "Skipping the step, no bundle_identifier available."
+              echo "debug only, skipping app name check with App Center"
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,22 +243,6 @@ jobs:
             TERM: dumb
 
       - run:
-          name: App Center Upload Unsigned .apk
-          command: |
-            export build_type=debug
-
-            if [ -z "$flavor" ];
-            then
-              export flavor=mobile
-            fi
-            app_name_no_whitespaces=${bundle_identifier//[^a-zA-Z0-9]/_};
-            apk_path=app/build/outputs/apk/${flavor}/debug/app-${flavor}-debug.apk
-            cp ${apk_path} ${HOME}/${app_name_no_whitespaces}-debug.apk;
-            bundle exec fastlane app_center_apk_upload
-          environment:
-            TERM: dumb
-
-      - run:
           name: App Center Upload Signed .apk
           command: |
             if [ -z "$key_store_url" ];


### PR DESCRIPTION
### Detailed readable description

We now use S3 to keep builds, so MS AppCenter distribute is not needed for debug unsigned builds. Saves 20-40 seconds in CI.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [x] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
