### PR TITLE
fix: only apply webview resolution from QB 5.0.1-rc.22 onward

### DIFF
--- a/rake/lib/template_helper.rb
+++ b/rake/lib/template_helper.rb
@@ -6,6 +6,7 @@ require "dependency_helper"
 require "android_manifest_helper"
 require "yaml"
 require "workspace_helper"
+require "versionomy"
 
 class TemplateHelper
   include DependencyHelper
@@ -14,13 +15,44 @@ class TemplateHelper
   SDK_DEFAULT_QB_VERSION = "5.0.0"
   SDK_DEFAULT_MIN_SDK_VERSION = 19
 
-  def render_template(template_path, dst_path)
+  def render_template(template_path, dst_path, obj = {})
     helper_binding = binding
+
+    unless obj.empty?
+      obj.each do |key, value|
+        helper_binding.local_variable_set(key, value)
+      end
+    end
+
     File.open(File.join("rake", "templates", template_path), "r") do |template|
       File.open(dst_path, "w+") do |dst|
         dst.write(ERB.new(template.read, nil, "-").result(helper_binding))
       end
     end
+  end
+
+  def quick_brick_enabled
+    ENV["quick_brick_enabled"].to_s == "true"
+  end
+
+  # Use either provided quick_brick_version from configuration,
+  # or the default version set for the current android sdk.
+  def quick_brick_version
+    return SDK_DEFAULT_QB_VERSION if ENV["quick_brick_version"] == "sdk_default"
+
+    ENV["quick_brick_version"].presence || SDK_DEFAULT_QB_VERSION
+  end
+
+  # Tells wether or not the package.json should have the resolutions property
+  # This is required to properly support JS2Native from QB 5.0.1-rc.22 onwards
+  def should_set_resolutions
+    return true if quick_brick_version == "next"
+
+    Versionomy.parse(quick_brick_version) > WEBVIEW_RESOLUTIONS_MIN_VERSION
+  rescue Versionomy::Errors::ParseError
+    # when building on a canary, Versionomy will fail to parse the version
+    # number. In this case, instead of failing, we apply the resolution
+    true
   end
 
   private
@@ -267,18 +299,6 @@ class TemplateHelper
 
   def environment_device_target
     ENV["device_target"]
-  end
-
-  def quick_brick_enabled
-    ENV["quick_brick_enabled"].to_s == "true"
-  end
-
-  # Use either provided quick_brick_version from configuration,
-  # or the default version set for the current android sdk.
-  def quick_brick_version
-    return SDK_DEFAULT_QB_VERSION if ENV["quick_brick_version"] == "sdk_default"
-
-    ENV["quick_brick_version"].presence || SDK_DEFAULT_QB_VERSION
   end
 
   def app_center_secret

--- a/rake/tasks/build.rake
+++ b/rake/tasks/build.rake
@@ -15,6 +15,8 @@ require "curb"
 require "zip"
 require "pry"
 
+WEBVIEW_RESOLUTIONS_MIN_VERSION = "5.0.1-rc.22"
+
 desc "submodule update"
 task submodule_update: :dotenv do
   system("git submodule update --init --recursive")
@@ -56,7 +58,9 @@ task render_templates: :dotenv do
   )
 
   puts "Generating package.json file...".green
-  template_helper.render_template("package.json.erb", "package.json")
+  options = {}
+  options["should_set_resolutions"] = template_helper.should_set_resolutions
+  template_helper.render_template("package.json.erb", "package.json", options)
 
   puts "Generating applicaster.properties file...".green
   template_helper.render_template(

--- a/rake/templates/package.json.erb
+++ b/rake/templates/package.json.erb
@@ -26,7 +26,7 @@
     "react-native-webview": "11.3.1"
   },
   "resolutions": {
-    "react-native-webview": "11.3.1"
+    <% if should_set_resolutions %>"react-native-webview": "11.3.1"<% end %>
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
### Detailed readable description
This PR fixes the issue with webview resolutions, only applying it from the version that requires it

### Checklist
- [ ] I've provided a readable title for the PR
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
