### PR TITLE
fix: RTL layout issues on TV

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
@@ -455,6 +455,9 @@ public class QuickBrickManager implements
         String appLocale = AppData.getLocale().toString();
         String localeToUse = languageList.isEmpty() || languageList.contains(appLocale)
                 ? appLocale : languageList.get(0);
+
+        I18nUtil.getInstance().allowRTL(this.rootActivity, false);
+
         I18nUtil.getInstance().forceRTL(
                 this.rootActivity,
                 RTL_LOCALES.includes(localeToUse)

--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
@@ -42,9 +42,6 @@ import java.util.List;
 
 import okhttp3.OkHttpClient;
 
-import android.app.UiModeManager;
-import android.content.res.Configuration;
-
 public class QuickBrickManager implements
         IUILayerManager,
         DefaultHardwareBackBtnHandler,
@@ -453,28 +450,21 @@ public class QuickBrickManager implements
                 .emit(RN_EVENT_HANDLE_OPEN_URL, resultMap);
     }
 
-    /**
-     * Check if app runs on TV platform.
-     **/
-    private boolean isTVPlatform() {
-        UiModeManager uiModeManager = (UiModeManager) this.rootActivity.getSystemService(Context.UI_MODE_SERVICE);
-        return uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
-    }
-
     public void setRightToLeftFlag() {
-        List<String> languageList = AppData.getAvailableLocalizations();
-        String appLocale = AppData.getLocale().toString();
-        String localeToUse = languageList.isEmpty() || languageList.contains(appLocale)
-                ? appLocale : languageList.get(0);
-
-        if(isTVPlatform()) {
+        if (OSUtil.isTv()) {
             I18nUtil.getInstance().allowRTL(this.rootActivity, false);
-        }
+            I18nUtil.getInstance().forceRTL(this.rootActivity, false);
+        } else {
+            List<String> languageList = AppData.getAvailableLocalizations();
+            String appLocale = AppData.getLocale().toString();
+            String localeToUse = languageList.isEmpty() || languageList.contains(appLocale)
+                    ? appLocale : languageList.get(0);
 
-        I18nUtil.getInstance().forceRTL(
-                this.rootActivity,
-                RTL_LOCALES.includes(localeToUse)
-        );
+            I18nUtil.getInstance().forceRTL(
+                    this.rootActivity,
+                    RTL_LOCALES.includes(localeToUse)
+            );
+        }
     }
 
     @Override

--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
@@ -42,6 +42,9 @@ import java.util.List;
 
 import okhttp3.OkHttpClient;
 
+import android.app.UiModeManager;
+import android.content.res.Configuration;
+
 public class QuickBrickManager implements
         IUILayerManager,
         DefaultHardwareBackBtnHandler,
@@ -450,13 +453,23 @@ public class QuickBrickManager implements
                 .emit(RN_EVENT_HANDLE_OPEN_URL, resultMap);
     }
 
+    /**
+     * Check if app runs on TV platform.
+     **/
+    private boolean isTVPlatform() {
+        UiModeManager uiModeManager = (UiModeManager) this.rootActivity.getSystemService(Context.UI_MODE_SERVICE);
+        return uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
+    }
+
     public void setRightToLeftFlag() {
         List<String> languageList = AppData.getAvailableLocalizations();
         String appLocale = AppData.getLocale().toString();
         String localeToUse = languageList.isEmpty() || languageList.contains(appLocale)
                 ? appLocale : languageList.get(0);
 
-        I18nUtil.getInstance().allowRTL(this.rootActivity, false);
+        if(isTVPlatform()) {
+            I18nUtil.getInstance().allowRTL(this.rootActivity, false);
+        }
 
         I18nUtil.getInstance().forceRTL(
                 this.rootActivity,


### PR DESCRIPTION
### Description
[Monday Ticket](https://applicaster.monday.com/boards/1139872912/pulses/1175412060)
Issues happen when we set a device to use hebrew as a language.

Before:
![Screenshot 2021-03-31 at 12 19 22](https://user-images.githubusercontent.com/74662382/113124955-c2cfbb00-921e-11eb-9fad-f767a21ae733.png)

After:
![Screenshot 2021-03-31 at 12 44 27](https://user-images.githubusercontent.com/74662382/113125293-1f32da80-921f-11eb-8cd6-42ab77c5231f.png)

Steps to reproduced: 
- Open Kan TV [v.51.0.0](https://zapp.applicaster.com/app_families/878/releases/544) on Android TV;
- Starting position is wrong for scroll list. When I press down button and the list gets focus, the focus cell is first on the left but focus border on the right;
- Focus border does not move correctly. When I press right button, border moves to left;
- Text alignment is wrong;

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [ ] My PR is not introducing a UI change
- [x] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [x] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result
