### PR TITLE
feat: increase node js memory in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ references:
   workspace_root: &workspace_root ~/zapp-platform-android
   container_config: &container_config
     working_directory: *workspace_root
-    resource_class: large
+    resource_class: xlarge
     docker:
       - image: applicaster/zapp-platform-android-circleci-primary:1.1.0
         environment:
@@ -12,7 +12,7 @@ references:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx6144M -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
           RAILS_ENV: test
           RACK_ENV: test
-          NODE_OPTIONS: --max_old_space_size=6144
+          NODE_OPTIONS: --max_old_space_size=16536
 
   gems_cache_key: &gems_cache_key Zapp-Platform-Android-v1-{{ checksum "Gemfile.lock" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx6144M -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
           RAILS_ENV: test
           RACK_ENV: test
-          NODE_OPTIONS: --max_old_space_size=8192
+          NODE_OPTIONS: --max_old_space_size=6144
 
   gems_cache_key: &gems_cache_key Zapp-Platform-Android-v1-{{ checksum "Gemfile.lock" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ references:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx6144M -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
           RAILS_ENV: test
           RACK_ENV: test
+          NODE_OPTIONS: --max_old_space_size=8192
 
   gems_cache_key: &gems_cache_key Zapp-Platform-Android-v1-{{ checksum "Gemfile.lock" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx6144M -XX:MaxPermSize=1024m -Xms512m -XX:+HeapDumpOnOutOfMemoryError"'
           RAILS_ENV: test
           RACK_ENV: test
-          NODE_OPTIONS: --max_old_space_size=16536
+          NODE_OPTIONS: --max_old_space_size=12288
 
   gems_cache_key: &gems_cache_key Zapp-Platform-Android-v1-{{ checksum "Gemfile.lock" }}
 


### PR DESCRIPTION
### Detailed readable description

Sometimes we have node build errors in CI.
```
$ mkdir -p android && node_modules/.bin/react-native bundle --platform android --dev false --entry-file index.js --bundle-output ./android/main.jsbundle --reset-cache
warning: the transform cache was reset.
                 Welcome to React Native!
                Learn once, write anywhere
error ENOMEM: not enough memory, write. Run CLI with --verbose flag for more details.
Error: ENOMEM: not enough memory, write
    at Object.writeSync (fs.js:598:3)
```
This should solve it according to
https://discuss.circleci.com/t/unit-tests-enomem-not-enough-memory-read/35695

We have to bump CI runner class a bit to the xlarge to set limit to 12Gb (8Gb was not enough)
https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes

### Checklist
- [ ] I've provided a readable title for the PR
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
