### PR TITLE
fix: disable gestures library on TV since it breaks scaling

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
@@ -25,6 +25,7 @@ import com.applicaster.util.OSUtil;
 import com.applicaster.util.server.SSLPinner;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -64,7 +65,7 @@ public class QuickBrickManager implements
 
     private boolean blockTVKeyEmit = true;
 
-    private RNGestureHandlerEnabledRootView reactRootView;
+    private ReactRootView reactRootView;
 
     private boolean initialized;
 
@@ -369,7 +370,7 @@ public class QuickBrickManager implements
     @Override
     public void onReactContextInitialized(ReactContext context) {
         reactInstanceManager.removeReactInstanceEventListener(this);
-        reactRootView = new RNGestureHandlerEnabledRootView(rootActivity); // Extends ReactRootView
+        reactRootView = OSUtil.isTv() ? new ReactRootView(rootActivity) : new RNGestureHandlerEnabledRootView(rootActivity);
         initialized = true;
         reactRootView.startReactApplication(reactInstanceManager, REACT_NATIVE_MODULE_NAME, null);
     }


### PR DESCRIPTION
Using this library breaks our x2 dpi scaling hack on TVs, so we disable it. But looks like it must be disabled on RN as well.

### Checklist
- [ ] I've provided a readable title for the PR
- [ ] I've provided a detailed description
- [ ] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [ ] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
