### PR TITLE
feat: intercept and handle RN exceptions

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
@@ -276,9 +276,10 @@ class MainActivity : HostActivityBase() {
                 override fun onReady() = completableEmitter.onComplete()
 
                 override fun onError(e: Exception?) {
-                    APLogger.error(TAG, "QuickBrickManager error", e)
+                    APLogger.error(TAG, "QuickBrickManager error: ${e ?: " (no exception)"}", e)
                     val handler = Handler(Looper.getMainLooper())
-                    handler.post { // post on UI thread, some devices has issues with toasts on worker ones
+                    handler.post {
+                        // post on UI thread, some devices has issues with toasts on worker ones
                         Toast.makeText(
                                 AppContext.get(), // use app context so toast will survive past activity finish
                                 "QuickBrickManager critical error: $e. The Application will now close.",

--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
@@ -4,9 +4,11 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.text.TextUtils
 import android.view.KeyEvent
 import android.view.OrientationEventListener
+import android.widget.Toast
 import androidx.annotation.RawRes
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
@@ -23,10 +25,7 @@ import com.applicaster.ui.utils.OrientationUtils.nativeOrientationMapper
 import com.applicaster.ui.utils.OrientationUtils.normaliseOrientation
 import com.applicaster.ui.utils.OrientationUtils.supportOrientation
 import com.applicaster.ui.views.ApplicationPreloaderView
-import com.applicaster.util.APLogger
-import com.applicaster.util.AppData
-import com.applicaster.util.OSUtil
-import com.applicaster.util.UrlSchemeUtil
+import com.applicaster.util.*
 import com.applicaster.util.ui.APUIUtils
 import com.applicaster.util.ui.PreloaderListener
 import io.reactivex.Completable
@@ -278,7 +277,13 @@ class MainActivity : HostActivityBase() {
 
                 override fun onError(e: Exception?) {
                     APLogger.error(TAG, "QuickBrickManager error", e)
-                    val handler = Handler()
+                    val handler = Handler(Looper.getMainLooper())
+                    handler.post { // post on UI thread, some devices has issues with toasts on worker ones
+                        Toast.makeText(
+                                AppContext.get(), // use app context so toast will survive past activity finish
+                                "QuickBrickManager critical error: $e. The Application will now close.",
+                                Toast.LENGTH_LONG).show()
+                    }
                     handler.postDelayed({
                         finish() // Not very nice but we prefer failing hard and fast in this case
                     }, 1000)

--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
@@ -331,13 +331,13 @@ public class QuickBrickManager implements
         }
 
         return getQuickBrickReactManagerBuilder()
-            .setJSBundleFile("assets://" + JS_BUNDLE_PATH)
-            .setNativeModuleCallExceptionHandler(e -> {
-                APLogger.error(TAG, "Exception in ReactInstanceManager", e);
-                if (listener != null) listener.onError(e);
-                throw new RuntimeException(e);
-            })
-            .build();
+                .setJSBundleFile("assets://" + JS_BUNDLE_PATH)
+                .setNativeModuleCallExceptionHandler(e -> {
+                    APLogger.error(TAG, "Exception in ReactInstanceManager: " + e.getMessage(), e);
+                    if (listener != null) listener.onError(e);
+                    throw new RuntimeException(e);
+                })
+                .build();
     }
 
     /**
@@ -376,7 +376,7 @@ public class QuickBrickManager implements
     public void onReactContextInitialized(ReactContext context) {
         reactInstanceManager.removeReactInstanceEventListener(this);
         context.setNativeModuleCallExceptionHandler(e -> {
-            APLogger.error(TAG, "Exception in react native", e);
+            APLogger.error(TAG, "Exception in ReactContext" + e.getMessage(), e);
             if (listener != null) listener.onError(e);
             throw new RuntimeException(e); // this is what RN seems to do by default
         });

--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/quickbrick/QuickBrickManager.java
@@ -25,6 +25,7 @@ import com.applicaster.util.OSUtil;
 import com.applicaster.util.server.SSLPinner;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -34,7 +35,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
-import com.facebook.react.ReactRootView;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -332,6 +332,11 @@ public class QuickBrickManager implements
 
         return getQuickBrickReactManagerBuilder()
             .setJSBundleFile("assets://" + JS_BUNDLE_PATH)
+            .setNativeModuleCallExceptionHandler(e -> {
+                APLogger.error(TAG, "Exception in ReactInstanceManager", e);
+                if (listener != null) listener.onError(e);
+                throw new RuntimeException(e);
+            })
             .build();
     }
 
@@ -370,6 +375,12 @@ public class QuickBrickManager implements
     @Override
     public void onReactContextInitialized(ReactContext context) {
         reactInstanceManager.removeReactInstanceEventListener(this);
+        context.setNativeModuleCallExceptionHandler(e -> {
+            APLogger.error(TAG, "Exception in react native", e);
+            if (listener != null) listener.onError(e);
+            throw new RuntimeException(e); // this is what RN seems to do by default
+        });
+
         if (OSUtil.isTv()) {
             reactRootView = new ReactRootView(context); // Extends ReactRootView
         } else {
@@ -409,7 +420,7 @@ public class QuickBrickManager implements
                 break;
 
             default: {
-                Log.e(TAG, "Got unrecognized quickBrickEvent. eventName: " + eventName + " payload: " + payload.toString());
+                APLogger.error(TAG, "Got unrecognized quickBrickEvent. eventName: " + eventName + " payload: " + payload.toString());
                 break;
             }
         }


### PR DESCRIPTION
### Detailed readable description

Added RN error interceptor on native side so we can tell user why app failed to start.
Current policy is to show a toast and terminate after 1 second. Error will be logged to xray.
Termination was there originally but did never work.

![image](https://user-images.githubusercontent.com/24409942/116438454-74f9a300-a81c-11eb-9279-ba240af443e4.png)


### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [x] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [ ] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
