### PR TITLE
fix: view constructor ags are not nullable

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/views/AnimatedImageView.kt
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/views/AnimatedImageView.kt
@@ -7,17 +7,17 @@ import androidx.appcompat.widget.AppCompatImageView
 
 class AnimatedImageView : AppCompatImageView {
 
-    constructor(context: Context?)
+    constructor(context: Context)
             : super(context) {
         startDrawableAnimation()
     }
 
-    constructor(context: Context?, attrs: AttributeSet?)
+    constructor(context: Context, attrs: AttributeSet)
             : super(context, attrs) {
         startDrawableAnimation()
     }
 
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int)
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int)
             : super(context, attrs, defStyleAttr) {
         startDrawableAnimation()
     }


### PR DESCRIPTION
### Detailed readable description

View constructor ags are not nullable. New versions of Kotlin fail on error on that. 

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
