### PR TITLE
fix: handle url rewriting from firebase

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/activities/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : HostActivityBase() {
         return if (UrlSchemeUtil.isUrlScheme(url)) {
             // update intent in-place, and let caller proceed
             intent.data = uri
-            setIntent(intent)
+            setIntent(Intent(Intent.ACTION_VIEW, uri))
             APLogger.info(TAG, "Intent data was replaced with url extra: $url")
             false
         } else {
@@ -85,6 +85,7 @@ class MainActivity : HostActivityBase() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent) // save new intent in any case
         if (routeOrUpdateIntent(intent)) {
             // This was probably intent from Firebase Console Firebase Push when app was not active.
             // User has first launched the app, and then clicked the notification
@@ -92,9 +93,9 @@ class MainActivity : HostActivityBase() {
         }
         // Update current intent in any case,
         // since QB may still be launching, and will only check it later.
-        setIntent(intent)
         if (true == uiLayer?.isReady) {
-            val uri = UrlSchemeUtil.getUrlSchemeData(intent)
+            // get intent back since routeOrUpdateIntent can update it
+            val uri = UrlSchemeUtil.getUrlSchemeData(getIntent())
             if (null != uri) {
                 uiLayer!!.handleURL(uri.toString())
             }


### PR DESCRIPTION
### Detailed readable description

https://applicaster.monday.com/boards/1139872912/pulses/1374399269
Fix for message pushes received when app is running, but in the background.
Intent that we got when firebase itself handles the notification, was not transformed in that flow. Now we repack and replace entire intent in this flow and redeliver it to the rn in all message scenarios.
Data scenarios did work without issues. Reshet actually does not use message type pushes to deliver, so they would not have this bug in production.

Note:
Firebase has 2 types of pushes: message and data.
Data type pushes are always handled by our code. There is still different cases to consider, but they close to the some flows of the second type.
Message type pushes handled differently depending on the app state:
 - if app is not running or in the background, Firebase handles the push and creates the notification, but puts URL in another place in the intent (and on some Android versions also uses different notification styling). 
 - If app is in the foreground, message is passed to our code, even though it has message type structure (fields are in another place different)
   - then, depending on the app state:
     - if QB is not yet ready, we fix the format we've received from firebase, and update the start intent. QB will pick it up after initialization
     - if QB is running, we extract the url and deliver it from the code using `handleURL`(`url` RN event)
     - there is also an edge case when we both receive (so its going to our code) and click the notification while quickbrick is still starting (so we can't redirect it), in that case main activity will be restarted.

All these situations can combine, so we have about 8-10 actual flows.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
