### PR TITLE
fix: disable auto fix for video and always fit manually

### DIFF
--- a/android_quickbrick_app/src/main/java/com/applicaster/ui/views/ApplicationPreloaderView.java
+++ b/android_quickbrick_app/src/main/java/com/applicaster/ui/views/ApplicationPreloaderView.java
@@ -3,7 +3,6 @@ package com.applicaster.ui.views;
 import android.content.Context;
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Build;
 import android.util.AttributeSet;
 import android.view.SurfaceHolder;
 import android.view.View;
@@ -21,7 +20,6 @@ import com.applicaster.util.OSUtil;
 import com.applicaster.util.ui.PreloaderListener;
 
 import java.lang.ref.WeakReference;
-import java.util.Locale;
 
 public class ApplicationPreloaderView extends FrameLayout implements LifecycleObserver {
 
@@ -75,15 +73,12 @@ public class ApplicationPreloaderView extends FrameLayout implements LifecycleOb
                     listener.onIntroVideoFinished();
                     APLogger.warn(getClass().getSimpleName(), "couldn't play intro video");
                 } else {
-                    player.setVideoScalingMode(MediaPlayer.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING);
                     player.setDisplay(holder);
-                    if(hasAspectBug()) {
-                        player.setOnPreparedListener(mp -> {
-                            int viewWidth = videoView.getWidth();
-                            int viewHeight = videoView.getHeight();
-                            correctAspect(viewWidth, viewHeight, true);
-                        });
-                    }
+                    player.setOnPreparedListener(mp -> {
+                        int viewWidth = videoView.getWidth();
+                        int viewHeight = videoView.getHeight();
+                        correctAspect(viewWidth, viewHeight, true);
+                    });
                     player.setOnCompletionListener(mp -> {
                         videoView.getHolder().removeCallback(this);
                         ApplicationPreloaderView.this.setVisibility(View.GONE);
@@ -106,7 +101,7 @@ public class ApplicationPreloaderView extends FrameLayout implements LifecycleOb
                 int videoHeight = player.getVideoHeight();
                 int videoWidth = player.getVideoWidth();
                 // VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING does not actually works on most devices,
-                // fix it manually by scaling the view
+                // fix it manually by scaling the view. Scaling is ignored by the video itself, so it will just fill the view
                 if(0 == videoWidth || 0 == videoHeight) {
                     // the video is broken
                     if(warnUser) {
@@ -120,10 +115,6 @@ public class ApplicationPreloaderView extends FrameLayout implements LifecycleOb
                 } else if (ratioCorrection < 1) {
                     videoView.setScaleY(1 / ratioCorrection);
                 }
-            }
-
-            private boolean hasAspectBug() {
-                return !Build.BRAND.toLowerCase(Locale.ENGLISH).contains("samsung");
             }
 
             /**
@@ -146,9 +137,6 @@ public class ApplicationPreloaderView extends FrameLayout implements LifecycleOb
 
             @Override
             public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-                if(!hasAspectBug()) {
-                    return;
-                }
                 if(null == player) {
                     return;
                 }


### PR DESCRIPTION
### Detailed readable description

VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING does not actually works on most devices, and its not only non-Samsungs, but also me Pixels.
We fix it manually by scaling the view. Scaling is ignored for the video itself (view is just a hole in the layer, through that we can see the video been blitted by hardware), only size and offset are taken.

### Checklist
- [x] I've provided a readable title for the PR
- [x] I've provided a detailed description
- [x] The PR is scoped to a single task/feature
- [ ] I've included relevant tests (if tests are not included please provide the reason why they aren't)


### UI changes
> Check one of the following checkboxes
- [x] My PR is not introducing a UI change
- [ ] My PR is introducing UI changes and I provided all screenshots in the PR description

#### PR type
> check one of the following type and make sure all related checkboxes are checked.
- [ ] My PR is a part of a new feature or a feature improvement
    - [ ] I've provided a link in the description to the relevant card in the Zapp cycle feature rollout Trello board.
- [x] My PR is a bug fix
    - [ ] I provided a link in the description to the relevant Jira ticket  or provided the following in the PR description:
        - steps to reproduce a bug
        - expected result


### Having problem filling out the checklist / Conforming to guidelines - explain why and consult Zapp tech lead / Head of product
